### PR TITLE
Update build and run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(diffusion-f90 Fortran)
-set (DIFFUSION_VERSION 0.1)
+set(diffusion_pkg diffusion)
+project(${diffusion_pkg}f Fortran)
+
+set(diffusion_exe run_${CMAKE_PROJECT_NAME})
+set(diffusion_lib ${CMAKE_PROJECT_NAME})
+
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
 add_subdirectory(diffusion)
 add_subdirectory(tests)

--- a/diffusion/CMakeLists.txt
+++ b/diffusion/CMakeLists.txt
@@ -1,28 +1,16 @@
-configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/diffusion.pc.cmake
-        ${CMAKE_CURRENT_SOURCE_DIR}/diffusion.pc)
+set(diffusion_src diffusion.f90 main.f90)
 
-set(BUILD_SHARED_LIBS ON)
+add_executable(${diffusion_exe} ${diffusion_src})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
-set(diffusion_lib_sources diffusion.f90)
-add_library(diffusion ${diffusion_lib_sources})
-
-set(diffusion_sources main.f90 diffusion.f90)
-add_executable(run_diffusion ${diffusion_sources})
+add_library(${diffusion_lib} SHARED ${diffusion_src})
+target_link_libraries(${diffusion_lib})
 
 install(
-  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_diffusion
-  DESTINATION bin
-  COMPONENT diffusion)
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${diffusion_exe}
+  DESTINATION bin)
 install(
-  TARGETS diffusion
-  DESTINATION lib
-  COMPONENT diffusion)
-install(
-  FILES diffusion.pc
-  DESTINATION lib/pkgconfig)
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/diffusion.mod
+  TARGETS ${diffusion_lib}
   DESTINATION lib)
+install(
+  FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${diffusion_pkg}.mod
+  DESTINATION include)

--- a/diffusion/diffusion.f90
+++ b/diffusion/diffusion.f90
@@ -118,16 +118,17 @@ contains
   end subroutine solve_2d
 
   ! A helper routine for displaying model parameters.
-  subroutine print_info(model)
+  subroutine print_info(file_unit, model)
     type (diffusion_model), intent (in) :: model
+    integer :: file_unit
 
-    write(*,"(a10, i8)") "n_x:", model%n_x
-    write(*,"(a10, i8)") "n_y:", model%n_y
-    write(*,"(a10, f8.2)") "dx:", model%dx
-    write(*,"(a10, f8.2)") "dy:", model%dy
-    write(*,"(a10, f8.2)") "dt:", model%dt
-    write(*,"(a10, f8.2)") "t:", model%t
-    write(*,"(a10, f8.2)") "t_end:", model%t_end
+    write(file_unit,"(a10, i8)") "n_x:", model%n_x
+    write(file_unit,"(a10, i8)") "n_y:", model%n_y
+    write(file_unit,"(a10, f8.2)") "dx:", model%dx
+    write(file_unit,"(a10, f8.2)") "dy:", model%dy
+    write(file_unit,"(a10, f8.2)") "dt:", model%dt
+    write(file_unit,"(a10, f8.2)") "t:", model%t
+    write(file_unit,"(a10, f8.2)") "t_end:", model%t_end
   end subroutine print_info
 
   ! A helper routine that prints the current state of the model.

--- a/diffusion/diffusion.f90
+++ b/diffusion/diffusion.f90
@@ -131,14 +131,14 @@ contains
   end subroutine print_info
 
   ! A helper routine that prints the current state of the model.
-  subroutine print_values(model)
+  subroutine print_values(file_unit, model)
     type (diffusion_model), intent (in) :: model
-    integer :: i, j
+    integer :: file_unit, i, j
     character(len=30) :: rowfmt
 
     write(rowfmt,'(a,i4,a)') '(', model%n_x, '(1x,f6.1))'
     do i = 1, model%n_y
-       write(*,fmt=rowfmt) model%density(i,:)
+       write(file_unit,fmt=rowfmt) model%density(i,:)
     end do
   end subroutine print_values
 

--- a/diffusion/diffusion.pc.cmake
+++ b/diffusion/diffusion.pc.cmake
@@ -1,5 +1,0 @@
-Name: diffusion
-Description: An example of the diffusion equation in Fortran 90
-Version: ${DIFFUSION_VERSION}
-Libs: -L${CMAKE_INSTALL_PREFIX}/lib -ldiffusion
-Cflags: -I${CMAKE_INSTALL_PREFIX}/include

--- a/diffusion/main.f90
+++ b/diffusion/main.f90
@@ -25,8 +25,11 @@ program main
 
   open(file_unit,file=output_file)
 
-  write(file_unit,"(a)") "Start"
+  write(file_unit,"(a)") "Start model."
   call initialize_from_file(model, arg)
+
+  write(file_unit,"(a)") "Model info..."
+  call print_info(file_unit, model)
 
   write(file_unit,"(a)") "Model initial values..."
   call print_values(file_unit, model)
@@ -38,7 +41,7 @@ program main
   end do
 
   call cleanup(model)
-  write(file_unit,"(a)") "Finish"
+  write(file_unit,"(a)") "Finish model."
 
   close(file_unit)
 

--- a/diffusion/main.f90
+++ b/diffusion/main.f90
@@ -3,6 +3,7 @@ program main
   use diffusion
   implicit none
 
+  integer :: file_unit = 0
   integer :: arg_count = 0
   character (len=80) :: arg
   type (diffusion_model) :: model
@@ -13,25 +14,25 @@ program main
   end do
 
   if (len_trim(arg) == 0) then
-     write(*,"(a)") "Usage: run_diffusionf CONFIGURATION_FILE"
-     write(*,"(a)")
-     write(*,"(a)") "Run the diffusionf model with a configuration file."
+     write(file_unit,"(a)") "Usage: run_diffusionf CONFIGURATION_FILE"
+     write(file_unit,"(a)")
+     write(file_unit,"(a)") "Run the diffusionf model with a configuration file."
      return
   end if
 
-  write(*,"(a)") "Start"
+  write(file_unit,"(a)") "Start"
   call initialize_from_file(model, arg)
 
-  write(*,"(a)") "Model initial values..."
-  call print_values(model)
+  write(file_unit,"(a)") "Model initial values..."
+  call print_values(file_unit, model)
 
   do while (model%t < model%t_end)
      call advance_in_time(model)
-     write(*,"(a, f6.1)") "Model values at time = ", model%t
-     call print_values(model)
+     write(file_unit,"(a, f6.1)") "Model values at time = ", model%t
+     call print_values(file_unit, model)
   end do
 
   call cleanup(model)
-  write(*,"(a)") "Finish"
+  write(file_unit,"(a)") "Finish"
 
 end program main

--- a/diffusion/main.f90
+++ b/diffusion/main.f90
@@ -3,7 +3,9 @@ program main
   use diffusion
   implicit none
 
-  integer :: file_unit = 0
+  character (len=*), parameter :: output_file = "diffusionf.out"
+  integer, parameter :: file_unit = 1
+
   integer :: arg_count = 0
   character (len=80) :: arg
   type (diffusion_model) :: model
@@ -14,11 +16,14 @@ program main
   end do
 
   if (len_trim(arg) == 0) then
-     write(file_unit,"(a)") "Usage: run_diffusionf CONFIGURATION_FILE"
-     write(file_unit,"(a)")
-     write(file_unit,"(a)") "Run the diffusionf model with a configuration file."
+     write(*,"(a)") "Usage: run_diffusionf CONFIGURATION_FILE"
+     write(*,"(a)")
+     write(*,"(a)") "Run the diffusionf model with a configuration file."
+     write(*,"(a)") "Output is written to the file `diffusionf.out`."
      return
   end if
+
+  open(file_unit,file=output_file)
 
   write(file_unit,"(a)") "Start"
   call initialize_from_file(model, arg)
@@ -34,5 +39,7 @@ program main
 
   call cleanup(model)
   write(file_unit,"(a)") "Finish"
+
+  close(file_unit)
 
 end program main

--- a/diffusion/main.f90
+++ b/diffusion/main.f90
@@ -3,10 +3,24 @@ program main
   use diffusion
   implicit none
 
+  integer :: arg_count = 0
+  character (len=80) :: arg
   type (diffusion_model) :: model
 
+  do while (arg_count <= 1)
+    call get_command_argument(arg_count, arg)
+    arg_count = arg_count + 1
+  end do
+
+  if (len_trim(arg) == 0) then
+     write(*,"(a)") "Usage: run_diffusionf CONFIGURATION_FILE"
+     write(*,"(a)")
+     write(*,"(a)") "Run the diffusionf model with a configuration file."
+     return
+  end if
+
   write(*,"(a)") "Start"
-  call initialize_from_defaults(model)
+  call initialize_from_file(model, arg)
 
   write(*,"(a)") "Model initial values..."
   call print_values(model)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,21 +1,19 @@
 include(CTest)
 
-add_test(MODEL_IRF1 test_from_defaults)
-add_test(MODEL_IRF2 test_from_file)
+add_test(model_irf1 test_from_defaults)
+add_test(model_irf2 test_from_file)
 
-set(BUILD_SHARED_LIBS ON)
+set(model_irf1_src test_from_defaults.f90)
+set(model_irf2_src test_from_file.f90)
 
-include_directories(${CMAKE_BINARY_DIR}/diffusion)
+include_directories(${CMAKE_Fortran_MODULE_DIRECTORY})
 
-set(model_irf1_sources test_from_defaults.f90)
-set(model_irf2_sources test_from_file.f90)
+add_executable(test_from_defaults ${model_irf1_src})
+target_link_libraries(test_from_defaults ${diffusion_lib})
 
-add_executable(test_from_defaults ${model_irf1_sources})
-add_executable(test_from_file ${model_irf2_sources})
+add_executable(test_from_file ${model_irf2_src})
+target_link_libraries(test_from_file ${diffusion_lib})
 
 file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}/test.cfg
   DESTINATION ${CMAKE_BINARY_DIR}/tests)
-
-target_link_libraries(test_from_defaults diffusion)
-target_link_libraries(test_from_file diffusion)

--- a/tests/test_from_defaults.f90
+++ b/tests/test_from_defaults.f90
@@ -3,20 +3,21 @@ program test_model_sanity_from_defaults
   use diffusion
   implicit none
 
+  integer :: file_unit = 0
   type (diffusion_model) :: m
 
-  write(*,"(a)",advance="no") "Initializing..."
+  write(file_unit,"(a)",advance="no") "Initializing..."
   call initialize_from_defaults(m)
-  write(*,*) "Done."
+  write(file_unit,*) "Done."
 
-  write(*,"(a)") "Model info..."
+  write(file_unit,"(a)") "Model info..."
   call print_info(m)
 
-  write(*,"(a)") "Model initial values..."
-  call print_values(m)
+  write(file_unit,"(a)") "Model initial values..."
+  call print_values(file_unit, m)
 
-  write(*,"(a)", advance="no") "Cleaning up arrays..."
+  write(file_unit,"(a)", advance="no") "Cleaning up arrays..."
   call cleanup(m)
-  write(*,*) "Done"
+  write(file_unit,*) "Done"
 
 end program test_model_sanity_from_defaults

--- a/tests/test_from_defaults.f90
+++ b/tests/test_from_defaults.f90
@@ -11,7 +11,7 @@ program test_model_sanity_from_defaults
   write(file_unit,*) "Done."
 
   write(file_unit,"(a)") "Model info..."
-  call print_info(m)
+  call print_info(file_unit, m)
 
   write(file_unit,"(a)") "Model initial values..."
   call print_values(file_unit, m)

--- a/tests/test_from_file.f90
+++ b/tests/test_from_file.f90
@@ -3,22 +3,24 @@ program test_model_sanity_from_file
   use diffusion
   implicit none
 
+  character (len=*), parameter :: cfg_file = "test.cfg"
+
+  integer :: file_unit = 0
   type (diffusion_model) :: m
-  character (len=8) :: cfg_file = "test.cfg"
 
-  write(*,"(a20, a8)") "Configuration file: ", cfg_file
-  write(*,"(a)", advance="no") "Initializing..."
+  write(file_unit,"(a20, a8)") "Configuration file: ", cfg_file
+  write(file_unit,"(a)", advance="no") "Initializing..."
   call initialize_from_file(m, cfg_file)
-  write(*,*) "Done."
+  write(file_unit,*) "Done."
 
-  write(*,"(a)") "Model info..."
+  write(file_unit,"(a)") "Model info..."
   call print_info(m)
 
-  write(*,"(a)") "Model initial values..."
-  call print_values(m)
+  write(file_unit,"(a)") "Model initial values..."
+  call print_values(file_unit, m)
 
-  write(*,"(a)", advance="no") "Cleaning up arrays..."
+  write(file_unit,"(a)", advance="no") "Cleaning up arrays..."
   call cleanup(m)
-  write(*,*) "Done"
+  write(file_unit,*) "Done"
 
 end program test_model_sanity_from_file

--- a/tests/test_from_file.f90
+++ b/tests/test_from_file.f90
@@ -14,7 +14,7 @@ program test_model_sanity_from_file
   write(file_unit,*) "Done."
 
   write(file_unit,"(a)") "Model info..."
-  call print_info(m)
+  call print_info(file_unit, m)
 
   write(file_unit,"(a)") "Model initial values..."
   call print_values(file_unit, m)


### PR DESCRIPTION
This PR updates my simple diffusion model example with an improved CMake build process. I also spent some effort in making the main program nicer. It now takes a (required) configuration file as input on the command line

    $ run_diffusionf test.cfg

and writes output to a file, `diffusionf.out`.